### PR TITLE
Fix issue for "reposition" calculation on re-open

### DIFF
--- a/pgwmodal.js
+++ b/pgwmodal.js
@@ -78,6 +78,9 @@
         
         // Repositions the modal
         var reposition = function() {
+            // elements must be visible before height calculation
+            $('#pgwModal, #pgwModalWrapper').show();
+        
             var windows_height = $(window).height();
             var modal_height = $('#pgwModal .pm-body').height();
             var margin_top = Math.round((windows_height - modal_height)/3);
@@ -165,7 +168,6 @@
                 pushContent(pgwModal.config.content);
             }
 
-            $('#pgwModal, #pgwModalWrapper').show();
             $('body').addClass('pgwModal');
             $(document).trigger('PgwModal::Open');
             return true;


### PR DESCRIPTION
During the "create" flow the modals height and margin are properly
calculated.  However, any time after that the modal height is evaluated
as zero because height is evaluated before the "display:none" is removed
from the element.  Changing the location of the "jQuery.show()" command
remedies this situation and the modal height and margin are correct and
consistent.
