### PR TITLE
really make title optional + more custom close button

### DIFF
--- a/pgwmodal.js
+++ b/pgwmodal.js
@@ -12,6 +12,7 @@
         var pgwModal = {};
         var defaults = {
             close: true,
+            closeText: 'Close',
             maxWidth: 500,
             loading: 'Loading in progress...',
             error: 'An error has occured. Please try again in a few moments.'
@@ -37,8 +38,10 @@
             var appendBody = '<div id="pgwModalWrapper"></div>'
                 + '<div id="pgwModal">'
                 + '<div class="pm-container">'
-                + '<div class="pm-body">'
-                + '<a href="javascript:void(0)" class="pm-close" onclick="$.pgwModal(\'close\')"></a>';
+                + '<div class="pm-body">';
+            if (pgwModal.config.close) {
+                appendBody += '<span class="pm-close">'+pgwModal.config.closeText+'</span>';
+            }
             if (pgwModal.config.title) {
                 appendBody += '<div class="pm-title"></div>';
             }
@@ -47,6 +50,11 @@
                 + '</div>'
                 + '</div>';
             $('body').append(appendBody);
+            if (pgwModal.config.close) {
+                $('.pm-close').on('click', function() {
+                    $.pgwModal('close');
+                });
+            }
             $(document).trigger('PgwModal::Create');
             return true;
         };
@@ -123,12 +131,6 @@
                 create();
             } else {
                 reset();
-            }
-
-            if (! pgwModal.config.close) {
-                $('#pgwModal .pm-close').hide();
-            } else {
-                $('#pgwModal .pm-close').show();
             }
 
             if (pgwModal.config.title) {


### PR DESCRIPTION
Don't create "title" html if no title is provided (pgwModal.config.title) in config (prevents having to hide it in CSS).

This is pretty much my first pull-request, hope I did things correctly...
Please disregard tabs/spaces diffs, the only interesting ones are lines 41-45, sorry about that.

ALSO, from later edit/commit for pull request:
"Make Close button optional and customizable
- Add option "closeText" ;
- Change close button's html to something more agnostic/semantic than an `a` tag with empty href ;
- Add creating close button only if pgwModal.config.close is true (prevents from having to hide it later) ;
- And bind click event if necessary.

New call may look like :

```
    $('#heroContact a.btn').on('click', function(e) {
        e.preventDefault();
        $.pgwModal({
            target: $(this).attr('href'),
            closeText: '<i class="icon-close"></i><span class="visuallyHidden">Close</span>',
            maxWidth: 800,
            loading: '<i class="icon-loader"></i><span class="visuallyHidden">Loading...</span>'
        });
    });
```

"

Thanks! :)
