### PR TITLE
Add class .pgwModalOpen to body and html tag too - Update pgwmodal.js

### DIFF
--- a/pgwmodal.js
+++ b/pgwmodal.js
@@ -128,13 +128,13 @@
 
         // Returns the modal status
         var isOpen = function() {
-            return $('body').hasClass('pgwModalOpen');
+            return $('body, html').hasClass('pgwModalOpen');
         };
 
         // Close the modal
         var close = function() {
             $('#pgwModal, #pgwModalBackdrop').removeClass().hide();
-            $('body').css('padding-right', '').removeClass('pgwModalOpen');
+            $('body, html').css('padding-right', '').removeClass('pgwModalOpen');
 
             // Reset modal
             reset();
@@ -242,7 +242,7 @@
             }
 
             // Add CSS class on the body tag
-            $('body').addClass('pgwModalOpen');
+            $('body, html').addClass('pgwModalOpen');
 
             var currentScrollbarWidth = getScrollbarWidth();
             if (currentScrollbarWidth > 0) {


### PR DESCRIPTION
Consider adding CSS class 'pgwModalOpen' also to the html tag element and avoid "page scroll" when html selector has overflow-y property declared. In that case adding pgwModalOpen to the body tag element doesn't seem to be enough in order to avoid scrolling the page below the backdrop element. Not sure about ('body, html') as the best way of declaring the selectors and targeting the elements but you get the gist of it.
