### PR TITLE
Update pgwmodal.js

### DIFF
--- a/pgwmodal.js
+++ b/pgwmodal.js
@@ -117,6 +117,7 @@
 
             // Check for Zepto
             if (typeof child.innerWidth != 'function') {
+                container.remove();
                 return 0;
             }
 


### PR DESCRIPTION
without removing the temp container (zepto) iOS zooms into page by error
