### PR TITLE
Improve minifyability

### DIFF
--- a/pgwmodal.js
+++ b/pgwmodal.js
@@ -66,11 +66,11 @@
 
         // Angular compilation
         var angularCompilation = function() {
-            angular.element('body').injector().invoke(function($compile) {
+            angular.element('body').injector().invoke(['$compile', function($compile) {
                 var scope = angular.element($('#pgwModal .pm-content')).scope();
                 $compile($('#pgwModal .pm-content'))(scope);
                 scope.$digest();
-            });
+            }]);
             return true;
         };
 


### PR DESCRIPTION
PgwModal now gives problems when minifying in ASP.NET Bundles. This is because ASP.NET bundles also change the function variable names. 

However in 1 function you use $compile, which is detected by AngularJS by name. Because AngularJS detects the $compile service by name, the code stops working when the minifyer changes the variable name to, let's say 'r'. 

AngularJS adds the possibility to name the parameter using a string (which the minifyer leaves unharmed). 
So applying this change allows the code to be minified correctly.